### PR TITLE
Changed in and out animations to follow the Material Design specs.

### DIFF
--- a/lib/src/main/java/com/williammora/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/williammora/snackbar/Snackbar.java
@@ -281,13 +281,13 @@ public class Snackbar extends RelativeLayout {
                 public void run() {
                     dismiss();
                 }
-            }, mCustomDuration == -1 ? mDuration.getDuration() : mCustomDuration);
+            }, getDuration());
         }
     }
 
     private void startSnackbarAnimation() {
-        final Animation fadeOut = AnimationUtils.loadAnimation(getContext(), R.anim.fade_out);
-        fadeOut.setStartOffset(mCustomDuration == -1 ? mDuration.getDuration() : mCustomDuration);
+        final Animation fadeOut = AnimationUtils.loadAnimation(getContext(), R.anim.snackbar_out);
+        fadeOut.setStartOffset(getDuration());
         fadeOut.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {
@@ -309,7 +309,7 @@ public class Snackbar extends RelativeLayout {
 
             }
         });
-        Animation slideIn = AnimationUtils.loadAnimation(getContext(), R.anim.slide_in_from_bottom);
+        Animation slideIn = AnimationUtils.loadAnimation(getContext(), R.anim.snackbar_in);
         slideIn.setAnimationListener(new Animation.AnimationListener() {
             @Override
             public void onAnimationStart(Animation animation) {

--- a/lib/src/main/res/anim/fade_out.xml
+++ b/lib/src/main/res/anim/fade_out.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <alpha android:fromAlpha="1" android:toAlpha="0" android:duration="300"/>
-</set>

--- a/lib/src/main/res/anim/slide_in_from_bottom.xml
+++ b/lib/src/main/res/anim/slide_in_from_bottom.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<set xmlns:android="http://schemas.android.com/apk/res/android">
-    <translate android:fromYDelta="100%" android:toYDelta="0%" android:duration="200"/>
-</set>

--- a/lib/src/main/res/anim/snackbar_in.xml
+++ b/lib/src/main/res/anim/snackbar_in.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:duration="300"
+     android:interpolator="@android:interpolator/decelerate_quad">
+    <translate
+        android:fromYDelta="40%"
+        android:toYDelta="0%"/>
+    <alpha
+        android:fromAlpha="0.3"
+        android:toAlpha="1.0"/>
+</set>

--- a/lib/src/main/res/anim/snackbar_out.xml
+++ b/lib/src/main/res/anim/snackbar_out.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<alpha xmlns:android="http://schemas.android.com/apk/res/android"
+       android:duration="250"
+       android:fromAlpha="1.0"
+       android:interpolator="@android:interpolator/accelerate_quad"
+       android:toAlpha="0.0"/>


### PR DESCRIPTION
The Material Design specs appear to have the Snackbar in animation start from about 30% opacity and 60% of the way in (instead of sliding all the way from the bottom), similar to how the keyboard in animation works.

Also renamed animation resource files to snackbar_in and snackbar_out to make it less likely for the parent project to accidentally override the animations. Naming them snackbar_in and snackbar_out also allows people to intentionally override them with custom in and out animations.
