### PR TITLE
Simplify sample project

### DIFF
--- a/sample/src/main/java/com/nispok/sample/snackbar/utils/SnackbarManager.java
+++ b/sample/src/main/java/com/nispok/sample/snackbar/utils/SnackbarManager.java
@@ -17,11 +17,11 @@ public class SnackbarManager {
     private SnackbarManager() {
     }
 
-    public void show(Snackbar snackbar, Activity target) {
+    public void show(Snackbar snackbar) {
         if (currentSnackbar != null) {
             currentSnackbar.dismiss();
         }
         currentSnackbar = snackbar;
-        currentSnackbar.show(target);
+        currentSnackbar.show((Activity) currentSnackbar.getContext());
     }
 }


### PR DESCRIPTION
No need to pass the target `Activity`, because it can be extracted from the `Snackbar` itself.
