### PR TITLE
Removed bold style from action button.

### DIFF
--- a/lib/src/main/res/values/styles.xml
+++ b/lib/src/main/res/values/styles.xml
@@ -14,7 +14,6 @@
 
     <style name="Snackbar.Text.Action">
         <item name="android:textAllCaps">true</item>
-        <item name="android:textStyle">bold</item>
         <item name="android:textColor">@color/sb__action_text_color</item>
         <item name="android:background">@drawable/sb__btn_bg</item>
     </style>


### PR DESCRIPTION
The spec defines the action button to be Roboto Medium, however "bold" is
heavier than Roboto Medium for API < 21. Therefore the action button should just
be regular on API < 21.
