### PR TITLE
Changed EventListener methods to take a Snackbar instance as the paramet...

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/listeners/EventListener.java
+++ b/lib/src/main/java/com/nispok/snackbar/listeners/EventListener.java
@@ -1,5 +1,7 @@
 package com.nispok.snackbar.listeners;
 
+import com.nispok.snackbar.Snackbar;
+
 /**
  * Interface used to notify of all {@link com.nispok.snackbar.Snackbar} display events. Useful if you want
  * to move other views while the Snackbar is on screen.
@@ -8,14 +10,14 @@ public interface EventListener {
     /**
      * Called when a {@link com.nispok.snackbar.Snackbar} is about to enter the screen
      *
-     * @param height {@link com.nispok.snackbar.Snackbar} total height (including offset), in DP
+     * @param snackbar the {@link com.nispok.snackbar.Snackbar} that's being shown
      */
-    public void onShow(int height);
+    public void onShow(Snackbar snackbar);
 
     /**
      * Called when a {@link com.nispok.snackbar.Snackbar} had just been dismissed
      *
-     * @param height {@link com.nispok.snackbar.Snackbar} total height (including offset), in DP
+     * @param snackbar the {@link com.nispok.snackbar.Snackbar} that's being dismissed
      */
-    public void onDismiss(int height);
+    public void onDismiss(Snackbar snackbar);
 }

--- a/lib/src/main/java/com/nispok/snackbar/listeners/SwipeDismissTouchListener.java
+++ b/lib/src/main/java/com/nispok/snackbar/listeners/SwipeDismissTouchListener.java
@@ -2,12 +2,10 @@ package com.nispok.snackbar.listeners;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
 import android.view.ViewConfiguration;
-import android.view.ViewGroup;
 
 /**
  * A {@link android.view.View.OnTouchListener} that makes any {@link android.view.View} dismissible
@@ -219,35 +217,6 @@ public class SwipeDismissTouchListener implements View.OnTouchListener {
     }
 
     private void performDismiss() {
-        // Animate the dismissed view to zero-height and then fire the dismiss callback.
-        // This triggers layout on each animation frame; in the future we may want to do something
-        // smarter and more performant.
-
-        final ViewGroup.LayoutParams lp = mView.getLayoutParams();
-        final int originalHeight = mView.getHeight();
-
-        ValueAnimator animator = ValueAnimator.ofInt(originalHeight, 1).setDuration(mAnimationTime);
-
-        animator.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                mCallbacks.onDismiss(mView, mToken);
-                // Reset view presentation
-                mView.setAlpha(1f);
-                mView.setTranslationX(0);
-                lp.height = originalHeight;
-                mView.setLayoutParams(lp);
-            }
-        });
-
-        animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-            @Override
-            public void onAnimationUpdate(ValueAnimator valueAnimator) {
-                lp.height = (Integer) valueAnimator.getAnimatedValue();
-                mView.setLayoutParams(lp);
-            }
-        });
-
-        animator.start();
+        mCallbacks.onDismiss(mView, mToken);
     }
 }

--- a/sample/src/main/java/com/nispok/sample/snackbar/SnackbarSampleActivity.java
+++ b/sample/src/main/java/com/nispok/sample/snackbar/SnackbarSampleActivity.java
@@ -1,11 +1,5 @@
 package com.nispok.sample.snackbar;
 
-import com.nispok.sample.snackbar.utils.SnackbarManager;
-import com.nispok.snackbar.Snackbar;
-import com.nispok.snackbar.enums.SnackbarType;
-import com.nispok.snackbar.listeners.ActionClickListener;
-import com.nispok.snackbar.listeners.EventListener;
-
 import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
@@ -18,6 +12,12 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
+
+import com.nispok.sample.snackbar.utils.SnackbarManager;
+import com.nispok.snackbar.Snackbar;
+import com.nispok.snackbar.enums.SnackbarType;
+import com.nispok.snackbar.listeners.ActionClickListener;
+import com.nispok.snackbar.listeners.EventListener;
 
 public class SnackbarSampleActivity extends ActionBarActivity {
 
@@ -111,14 +111,19 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                                 .text("I'm showing a toast on exit")
                                 .eventListener(new EventListener() {
                                     @Override
-                                    public void onShow(int height) {
-                                        Log.i(TAG, "Snackbar will show. Height: " + height);
+                                    public void onShow(Snackbar snackbar) {
+                                        Log.i(TAG, String.format(
+                                                "Snackbar will show. Width: %d Height: %d Offset: %d",
+                                                snackbar.getWidth(), snackbar.getHeight(),
+                                                snackbar.getOffset()));
                                     }
 
                                     @Override
-                                    public void onDismiss(int height) {
-                                        Toast.makeText(SnackbarSampleActivity.this,
-                                                "Snackbar dismissed. Height in DP: " + height,
+                                    public void onDismiss(Snackbar snackbar) {
+                                        Toast.makeText(SnackbarSampleActivity.this, String.format(
+                                                "Snackbar dismissed. Width: %d Height: %d Offset: %d",
+                                                        snackbar.getWidth(), snackbar.getHeight(),
+                                                        snackbar.getOffset()),
                                                 Toast.LENGTH_SHORT).show();
                                     }
                                 }));


### PR DESCRIPTION
...er.

This allows users to:
- differentiate between Snackbar instances in common EventListener
  implementations
- get the width, height, and offset from the Snackbar in pixels (or any other
  relevant info about the Snackbar)

Also made sure that the width/height values are valid when onShow() is called
and prevented the dismiss listener from making the height of the Snackbar 0
before calling onDismiss() when swiping the Snackbar away (this logic was there
for swiping away list items, which a Snackbar is not).
