### PR TITLE
Add bottom margin if content is fitting system ui

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -439,7 +439,13 @@ public class Snackbar extends SnackbarLayout {
         FrameLayout.LayoutParams params = init(targetActivity);
 
         ViewGroup root = (ViewGroup) targetActivity.findViewById(android.R.id.content);
-
+        if (root.getMeasuredHeight() == root.getBottom()) {
+            Resources resources = targetActivity.getResources();
+            int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+            if (resourceId > 0) {
+                params.bottomMargin = resources.getDimensionPixelSize(resourceId);
+            }
+        }
         root.addView(this, params);
 
         bringToFront();


### PR DESCRIPTION
If the content is fitting the system windows the snackbar gets animated behind the navigation bar. Therefore check if the measured height equals the bottom position of the content view. If it does add a the navigation bar height as bottom margin.

This is rough workaround, further checks need to be added if required.

This might resolve issue #41.
