### PR TITLE
Add delay to Snackbar dismiss then show with SnackbarManager

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
@@ -52,6 +52,9 @@ public class SnackbarManager {
             }, activity.getResources().getInteger(R.integer.sb__anim_duration));
 
             currentSnackbar.dismiss();
+        } else {
+            currentSnackbar = snackbar;
+            currentSnackbar.show(activity);
         }
     }
 

--- a/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
@@ -41,12 +41,18 @@ public class SnackbarManager {
      * @param snackbar instance of {@link com.nispok.snackbar.Snackbar} to display
      * @param activity target {@link Activity} to display the Snackbar
      */
-    public static void show(@NonNull Snackbar snackbar, @NonNull Activity activity) {
+    public static void show(@NonNull final Snackbar snackbar, @NonNull final Activity activity) {
         if (currentSnackbar != null) {
+            currentSnackbar.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    currentSnackbar = snackbar;
+                    currentSnackbar.show(activity);
+                }
+            }, activity.getResources().getInteger(R.integer.sb__anim_duration));
+
             currentSnackbar.dismiss();
         }
-        currentSnackbar = snackbar;
-        currentSnackbar.show(activity);
     }
 
     /**

--- a/lib/src/main/res/anim/sb__in.xml
+++ b/lib/src/main/res/anim/sb__in.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="300"
+    android:duration="@integer/sb__anim_duration"
     android:fromYDelta="100%"
     android:interpolator="@interpolator/sb__decelerate_cubic"
     android:toYDelta="0%" />

--- a/lib/src/main/res/anim/sb__out.xml
+++ b/lib/src/main/res/anim/sb__out.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <translate xmlns:android="http://schemas.android.com/apk/res/android"
-    android:duration="300"
+    android:duration="@integer/sb__anim_duration"
     android:fromYDelta="0%"
     android:interpolator="@interpolator/sb__accelerate_cubic"
     android:toYDelta="100%" />

--- a/lib/src/main/res/values/integers.xml
+++ b/lib/src/main/res/values/integers.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <integer name="sb__anim_duration">300</integer>
+
+</resources>


### PR DESCRIPTION
As stated in #52 the Snackbar should be full dismissed before another one is to take its place. I've modified SnackbarManager to use a `postDelayed(Runnable, int);` call to delay the `show(Activity);` call until the Snackbar has (supposedly) displayed.

Haven't got a device to hand to test it, so someone will need to test it before this gets merged