### PR TITLE
Disallow action btn to be clicked multiple times or when dismissing

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -61,6 +61,8 @@ public class Snackbar extends SnackbarLayout {
     private boolean mAnimated = true;
     private long mCustomDuration = -1;
     private ActionClickListener mActionClickListener;
+    private boolean mShouldAllowMultipleActionClicks;
+    private boolean mActionClicked;
     private boolean mShouldDismissOnActionClicked = true;
     private EventListener mEventListener;
     private Typeface mTextTypeface;
@@ -224,6 +226,19 @@ public class Snackbar extends SnackbarLayout {
      */
     public Snackbar actionListener(ActionClickListener listener) {
         mActionClickListener = listener;
+        return this;
+    }
+
+    /**
+     * Determines whether this {@link Snackbar} should allow the action button to be
+     * clicked multiple times
+     *
+     * @param shouldAllow
+     * @return
+     */
+    public Snackbar allowMultipleActionClicks(boolean shouldAllow){
+
+        mShouldAllowMultipleActionClicks = shouldAllow;
         return this;
     }
 
@@ -407,7 +422,15 @@ public class Snackbar extends SnackbarLayout {
                 @Override
                 public void onClick(View view) {
                     if (mActionClickListener != null) {
-                        mActionClickListener.onActionClicked(Snackbar.this);
+
+                        // Before calling the onActionClicked() callback, make sure:
+                        // 1) The snackbar is not dismissing
+                        // 2) If we aren't allowing multiple clicks, that this is the first click
+                        if (!mIsDismissing && (!mActionClicked || mShouldAllowMultipleActionClicks)) {
+
+                            mActionClickListener.onActionClicked(Snackbar.this);
+                            mActionClicked = true;
+                        }
                     }
                     if (mShouldDismissOnActionClicked) {
                         dismiss();


### PR DESCRIPTION
Previously, the action button could be clicked while the snackbar is dismissing as well as clicked multiple times (spam click while dismissing) which would result in the onActionClicked() callback being called multiple times. Considering the common uses of Snackbar, I feel like that should be undesired. Now, when the action button is clicked, it checks two things before calling the callback:

1) The snackbar is not dismissing
2) That it is the first time the button is being clicked unless multiple clicks are allowed (disabled by default)