### PR TITLE
Support for translucent navigation bars and extension of EventListener interface.

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
@@ -43,6 +43,12 @@ public class SnackbarManager {
      */
     public static void show(@NonNull Snackbar snackbar, @NonNull Activity activity) {
         if (currentSnackbar != null) {
+            if(currentSnackbar.isShowing() && !currentSnackbar.isDimissing()) {
+                currentSnackbar.dismissByReplace();
+                currentSnackbar = snackbar;
+                currentSnackbar.showByReplace(activity);
+                return;
+            }
             currentSnackbar.dismiss();
         }
         currentSnackbar = snackbar;

--- a/lib/src/main/java/com/nispok/snackbar/listeners/EventListener.java
+++ b/lib/src/main/java/com/nispok/snackbar/listeners/EventListener.java
@@ -15,6 +15,14 @@ public interface EventListener {
     public void onShow(Snackbar snackbar);
 
     /**
+     * Called when a {@link com.nispok.snackbar.Snackbar} is about to enter the screen while
+     * a {@link com.nispok.snackbar.Snackbar} is about to exit the screen by replacement.
+     *
+     * @param snackbar the {@link com.nispok.snackbar.Snackbar} that's being shown
+     */
+    public void onShowByReplace(Snackbar snackbar);
+
+    /**
      * Called when a {@link com.nispok.snackbar.Snackbar} is fully shown
      *
      * @param snackbar the {@link com.nispok.snackbar.Snackbar} that's being shown
@@ -27,6 +35,14 @@ public interface EventListener {
      * @param snackbar the {@link com.nispok.snackbar.Snackbar} that's being dismissed
      */
     public void onDismiss(Snackbar snackbar);
+
+    /**
+     * Called when a {@link com.nispok.snackbar.Snackbar} is about to exit the screen
+     * when a new {@link com.nispok.snackbar.Snackbar} is about to enter the screen.
+     *
+     * @param snackbar the {@link com.nispok.snackbar.Snackbar} that's being dismissed
+     */
+    public void onDismissByReplace(Snackbar snackbar);
 
     /**
      * Called when a {@link com.nispok.snackbar.Snackbar} had just been dismissed

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         </activity>
         <activity android:name=".SnackbarListViewSampleActivity" />
         <activity android:name=".SnackbarRecyclerViewSampleActivity" />
+        <activity android:name=".SnackbarNavigationBarTranslucentSampleActivity" />
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarNavigationBarTranslucentSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarNavigationBarTranslucentSampleActivity.java
@@ -1,0 +1,84 @@
+package com.nispok.samples.snackbar;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.Button;
+
+import com.nispok.snackbar.Snackbar;
+import com.nispok.snackbar.SnackbarManager;
+import com.nispok.snackbar.enums.SnackbarType;
+
+public class SnackbarNavigationBarTranslucentSampleActivity extends ActionBarActivity {
+
+    private static final String TAG = SnackbarNavigationBarTranslucentSampleActivity.class.getSimpleName();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_navigation_bar_translucent_sample);
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        enableTransparentSystemBars(getWindow());
+
+        Button singleLineButton = (Button) findViewById(R.id.single_line);
+        singleLineButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SnackbarManager.show(
+                        Snackbar.with(SnackbarNavigationBarTranslucentSampleActivity.this)
+                                .text("Single-line snackbar"));
+            }
+        });
+
+        Button multiLineButton = (Button) findViewById(R.id.multi_line);
+        multiLineButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SnackbarManager.show(
+                        Snackbar.with(SnackbarNavigationBarTranslucentSampleActivity.this)
+                                .type(SnackbarType.MULTI_LINE)
+                                .text("This is a multi-line snackbar. Keep in mind that snackbars" +
+                                        " are meant for VERY short messages"));
+            }
+        });
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        disableTransparentSystemBars(getWindow());
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch(item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static boolean isTranslucentSystemBarsCapable() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private void enableTransparentSystemBars(Window window) {
+        window.setFlags(
+                WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION,
+                WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private void disableTransparentSystemBars(Window window) {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+    }
+}

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
@@ -120,6 +120,14 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                                     }
 
                                     @Override
+                                    public void onShowByReplace(Snackbar snackbar) {
+                                        Log.i(TAG, String.format(
+                                                "Snackbar will show by replace. Width: %d Height: %d Offset: %d",
+                                                snackbar.getWidth(), snackbar.getHeight(),
+                                                snackbar.getOffset()));
+                                    }
+
+                                    @Override
                                     public void onShown(Snackbar snackbar) {
                                         Log.i(TAG, String.format(
                                                 "Snackbar shown. Width: %d Height: %d Offset: %d",
@@ -131,6 +139,14 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                                     public void onDismiss(Snackbar snackbar) {
                                         Log.i(TAG, String.format(
                                                 "Snackbar will dismiss. Width: %d Height: %d Offset: %d",
+                                                snackbar.getWidth(), snackbar.getHeight(),
+                                                snackbar.getOffset()));
+                                    }
+
+                                    @Override
+                                    public void onDismissByReplace(Snackbar snackbar) {
+                                        Log.i(TAG, String.format(
+                                                "Snackbar will dismiss by replace. Width: %d Height: %d Offset: %d",
                                                 snackbar.getWidth(), snackbar.getHeight(),
                                                 snackbar.getOffset()));
                                     }
@@ -222,6 +238,23 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                         .textTypeface(tf)
                         .actionLabel("Cool")
                         .actionLabelTypeface(tf));
+            }
+        });
+
+        Button navigationBarTranslucentButton = (Button) findViewById(R.id.navigation_bar_translucent);
+        navigationBarTranslucentButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                if(SnackbarNavigationBarTranslucentSampleActivity.isTranslucentSystemBarsCapable()) {
+                    Intent sampleIntent = new Intent(SnackbarSampleActivity.this,
+                            SnackbarNavigationBarTranslucentSampleActivity.class);
+                    startActivity(sampleIntent);
+                } else {
+                    Toast.makeText(SnackbarSampleActivity.this,
+                            "Translucent System bars only available for KITKAT or newer",
+                            Toast.LENGTH_SHORT).show();
+                }
             }
         });
     }

--- a/sample/src/main/res/layout/activity_navigation_bar_translucent_sample.xml
+++ b/sample/src/main/res/layout/activity_navigation_bar_translucent_sample.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:gravity="center_vertical"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/single_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="SINGLE-LINE"/>
+
+    <Button
+        android:id="@+id/multi_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="MULTI-LINE"/>
+
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -85,5 +85,11 @@
             android:layout_height="wrap_content"
             android:text="Custom Typefaces" />
 
+        <Button
+            android:id="@+id/navigation_bar_translucent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Navigation Bar Translucent"/>
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Support for translucent navigation bar:

The Snackbar default behaviour is to appear above navigation bars. When using a translucent navigation bar, it's background area is not covered up by the Snackbar. 
For translucent navigation bars, I've added their height size in the Snackbar's bottom padding. I've added a sample called "Navigation Bar Translucent" to illustrate this.

Extension of EventListener interface: 

Added 2 new callbacks for EventListener: onShowByReplace and onDismissByReplace. This is useful if you need to NOT move a Floating Action Button down and up while the Snackbar is just being replaced, but still wanted to move up and down on regular show/dismiss callbacks.