### PR TITLE
Improve navigation bar handling

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/DisplayCompat.java
+++ b/lib/src/main/java/com/nispok/snackbar/DisplayCompat.java
@@ -1,0 +1,33 @@
+package com.nispok.snackbar;
+
+import android.graphics.Point;
+import android.os.Build;
+import android.view.Display;
+
+class DisplayCompat {
+    static abstract class Impl {
+        abstract void getSize(Display display, Point outSize);
+
+        abstract void getRealSize(Display display, Point outSize);
+    }
+
+    private static final Impl IMPL;
+
+    static {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            IMPL = new DisplayCompatImplJBMR1();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR2) {
+            IMPL = new DisplayCompatImplHoneycombMR2();
+        } else {
+            IMPL = new DisplayCompatImplPreHoneycombMR2();
+        }
+    }
+
+    public static void getSize(Display display, Point outSize) {
+        IMPL.getSize(display, outSize);
+    }
+
+    public static void getRealSize(Display display, Point outSize) {
+        IMPL.getRealSize(display, outSize);
+    }
+}

--- a/lib/src/main/java/com/nispok/snackbar/DisplayCompatImplHoneycombMR2.java
+++ b/lib/src/main/java/com/nispok/snackbar/DisplayCompatImplHoneycombMR2.java
@@ -1,0 +1,19 @@
+package com.nispok.snackbar;
+
+import android.annotation.TargetApi;
+import android.graphics.Point;
+import android.os.Build;
+import android.view.Display;
+
+@TargetApi(Build.VERSION_CODES.HONEYCOMB_MR2)
+class DisplayCompatImplHoneycombMR2 extends DisplayCompat.Impl {
+    @Override
+    void getSize(Display display, Point outSize) {
+        display.getSize(outSize);
+    }
+
+    @Override
+    void getRealSize(Display display, Point outSize) {
+        display.getSize(outSize);
+    }
+}

--- a/lib/src/main/java/com/nispok/snackbar/DisplayCompatImplJBMR1.java
+++ b/lib/src/main/java/com/nispok/snackbar/DisplayCompatImplJBMR1.java
@@ -1,0 +1,19 @@
+package com.nispok.snackbar;
+
+import android.annotation.TargetApi;
+import android.graphics.Point;
+import android.os.Build;
+import android.view.Display;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+class DisplayCompatImplJBMR1 extends DisplayCompat.Impl {
+    @Override
+    void getSize(Display display, Point outSize) {
+        display.getSize(outSize);
+    }
+
+    @Override
+    void getRealSize(Display display, Point outSize) {
+        display.getRealSize(outSize);
+    }
+}

--- a/lib/src/main/java/com/nispok/snackbar/DisplayCompatImplPreHoneycombMR2.java
+++ b/lib/src/main/java/com/nispok/snackbar/DisplayCompatImplPreHoneycombMR2.java
@@ -1,0 +1,20 @@
+package com.nispok.snackbar;
+
+import android.graphics.Point;
+import android.view.Display;
+
+@SuppressWarnings("deprecation")
+class DisplayCompatImplPreHoneycombMR2 extends DisplayCompat.Impl {
+    @Override
+    void getSize(Display display, Point outSize) {
+        outSize.x = display.getWidth();
+        outSize.y = display.getHeight();
+    }
+
+    @Override
+    void getRealSize(Display display, Point outSize) {
+        outSize.x = display.getWidth();
+        outSize.y = display.getHeight();
+    }
+}
+

--- a/lib/src/main/java/com/nispok/snackbar/SnackbarHelperChildViewJB.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarHelperChildViewJB.java
@@ -1,0 +1,27 @@
+package com.nispok.snackbar;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewParent;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+class SnackbarHelperChildViewJB extends View {
+    public SnackbarHelperChildViewJB(Context context) {
+        super(context);
+        setSaveEnabled(false);
+        setWillNotDraw(true);
+        setVisibility(GONE);
+    }
+
+    @Override
+    public void onWindowSystemUiVisibilityChanged(int visible) {
+        super.onWindowSystemUiVisibilityChanged(visible);
+
+        final ViewParent parent = getParent();
+        if (parent instanceof Snackbar) {
+            ((Snackbar) parent).dispatchOnWindowSystemUiVisibilityChangedCompat(visible);
+        }
+    }
+}

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <activity android:name=".SnackbarListViewSampleActivity" />
         <activity android:name=".SnackbarRecyclerViewSampleActivity" />
         <activity android:name=".SnackbarNavigationBarTranslucentSampleActivity" />
+        <activity android:name=".SnackbarImmersiveModeSampleActivity" />
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarImmersiveModeSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarImmersiveModeSampleActivity.java
@@ -1,0 +1,121 @@
+package com.nispok.samples.snackbar;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Button;
+
+import com.nispok.snackbar.Snackbar;
+import com.nispok.snackbar.SnackbarManager;
+import com.nispok.snackbar.enums.SnackbarType;
+
+public class SnackbarImmersiveModeSampleActivity extends ActionBarActivity {
+
+    private static final String TAG = SnackbarImmersiveModeSampleActivity.class.getSimpleName();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_immersive_mode_sample);
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        hideSystemUI();
+
+        Button singleLineButton = (Button) findViewById(R.id.single_line);
+        singleLineButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SnackbarManager.show(
+                        Snackbar.with(SnackbarImmersiveModeSampleActivity.this)
+                                .text("Single-line snackbar"));
+            }
+        });
+
+        Button multiLineButton = (Button) findViewById(R.id.multi_line);
+        multiLineButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                SnackbarManager.show(
+                        Snackbar.with(SnackbarImmersiveModeSampleActivity.this)
+                                .type(SnackbarType.MULTI_LINE)
+                                .text("This is a multi-line snackbar. Keep in mind that snackbars" +
+                                        " are meant for VERY short messages"));
+            }
+        });
+
+        ViewGroup container = (ViewGroup) findViewById(android.R.id.content);
+        container.setClickable(true);
+        container.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onClickContainerView();
+            }
+        });
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static boolean isImmersiveModeCapable() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private void hideSystemUI() {
+        getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private void showSystemUI() {
+        getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    private boolean isSystemUiHidden() {
+        return ((getWindow().getDecorView().getSystemUiVisibility() & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+
+        if (hasFocus) {
+            hideSystemUI();
+        }
+    }
+
+    private void onClickContainerView() {
+        if (isSystemUiHidden()) {
+            showSystemUI();
+        } else {
+            hideSystemUI();
+        }
+    }
+}

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
@@ -257,6 +257,24 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                 }
             }
         });
+
+
+        Button immersiveModeButton = (Button) findViewById(R.id.immersive_mode_example);
+        immersiveModeButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                if(SnackbarImmersiveModeSampleActivity.isImmersiveModeCapable()) {
+                    Intent sampleIntent = new Intent(SnackbarSampleActivity.this,
+                            SnackbarImmersiveModeSampleActivity.class);
+                    startActivity(sampleIntent);
+                } else {
+                    Toast.makeText(SnackbarSampleActivity.this,
+                            "Immersive mode only available for KITKAT or newer",
+                            Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
     }
 
     @Override

--- a/sample/src/main/res/layout/activity_immersive_mode_sample.xml
+++ b/sample/src/main/res/layout/activity_immersive_mode_sample.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:gravity="center_vertical"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/single_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="SINGLE-LINE"/>
+
+    <Button
+        android:id="@+id/multi_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="MULTI-LINE"/>
+
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -91,5 +91,11 @@
             android:layout_height="wrap_content"
             android:text="Navigation Bar Translucent"/>
 
+        <Button
+            android:id="@+id/immersive_mode_example"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Immersive Mode"/>
+
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
This pull request fixes the issue #45.
- Automatically handles navigation bar visibility changes, and fully compatible with both software key and hardware key devices. 
- Added an Immersive mode sample to check navigation bar handling.

Tested on these devices;
- Nexus 5 (Phone / Lollipop)
- Nexus 9 (Tablet / Lollipop)
- Galaxy S4 (Phone / KitKat / Hardware key)
- Ployer momo9 (Tablet / JB MR1)
- Galaxy S2 (Phone / ICS / Hardware key)
- Motorola Photon 4G (Phone / Gingerbread / Hardware key)
