### PR TITLE
Attach to non-Activity's root view

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -24,6 +24,7 @@ import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.AbsListView;
 import android.widget.FrameLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.nispok.snackbar.enums.SnackbarType;
@@ -387,8 +388,29 @@ public class Snackbar extends SnackbarLayout {
         return this;
     }
 
-    private FrameLayout.LayoutParams init(Activity parent) {
-        SnackbarLayout layout = (SnackbarLayout) LayoutInflater.from(parent)
+    private static MarginLayoutParams createMarginLayoutParams(ViewGroup viewGroup, int width, int height) {
+        if (viewGroup instanceof FrameLayout) {
+            FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(width, height);
+            params.gravity = Gravity.BOTTOM;
+            return params;
+        } else if (viewGroup instanceof RelativeLayout) {
+            RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(width, height);
+            return params;
+        } else {
+            throw new IllegalStateException("Requires FrameLayout or RelativeLayout for the parent of Snackbar");
+        }
+    }
+
+    private boolean shouldUsePhoneLayout(Activity targetActivity) {
+        if (targetActivity == null) {
+            return true;
+        } else {
+            return targetActivity.getResources().getBoolean(R.bool.sb__is_phone);
+        }
+    }
+
+    private MarginLayoutParams init(Context context, Activity targetActivity, ViewGroup parent) {
+        SnackbarLayout layout = (SnackbarLayout) LayoutInflater.from(context)
                 .inflate(R.layout.sb__template, this, true);
 
         Resources res = getResources();
@@ -396,14 +418,14 @@ public class Snackbar extends SnackbarLayout {
         mOffset = res.getDimensionPixelOffset(R.dimen.sb__offset);
         float scale = res.getDisplayMetrics().density;
 
-        FrameLayout.LayoutParams params;
-        if (res.getBoolean(R.bool.sb__is_phone)) {
+        MarginLayoutParams params;
+        if (shouldUsePhoneLayout(targetActivity)) {
             // Phone
             layout.setMinimumHeight(dpToPx(mType.getMinHeight(), scale));
             layout.setMaxHeight(dpToPx(mType.getMaxHeight(), scale));
             layout.setBackgroundColor(mColor);
-            params = new FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+            params = createMarginLayoutParams(
+                    parent, FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT);
         } else {
             // Tablet/desktop
             mType = SnackbarType.SINGLE_LINE; // Force single-line
@@ -413,11 +435,9 @@ public class Snackbar extends SnackbarLayout {
             GradientDrawable bg = (GradientDrawable) layout.getBackground();
             bg.setColor(mColor);
 
-            params = new FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.WRAP_CONTENT, dpToPx(mType.getMaxHeight(), scale));
+            params = createMarginLayoutParams(
+                    parent, FrameLayout.LayoutParams.WRAP_CONTENT, dpToPx(mType.getMaxHeight(), scale));
         }
-
-        params.gravity = Gravity.BOTTOM;
 
         TextView snackbarText = (TextView) layout.findViewById(R.id.sb__text);
         snackbarText.setText(mText);
@@ -551,6 +571,11 @@ public class Snackbar extends SnackbarLayout {
         show(targetActivity);
     }
 
+    public void showByReplace(ViewGroup parent) {
+        mIsShowingByReplace = true;
+        show(parent);
+    }
+
     /**
      * Displays the {@link Snackbar} at the bottom of the
      * {@link android.app.Activity} provided.
@@ -558,21 +583,35 @@ public class Snackbar extends SnackbarLayout {
      * @param targetActivity
      */
     public void show(Activity targetActivity) {
-        FrameLayout.LayoutParams params = init(targetActivity);
-
-        updateLayoutParamsMargins(targetActivity, params);
-
         ViewGroup root = (ViewGroup) targetActivity.findViewById(android.R.id.content);
+        MarginLayoutParams params = init(targetActivity, targetActivity, root);
+        updateLayoutParamsMargins(targetActivity, params);
+        showInternal(targetActivity, params, root);
+    }
 
-        root.removeView(this);
-        root.addView(this, params);
+    /**
+     * Displays the {@link Snackbar} at the bottom of the
+     * {@link android.view.ViewGroup} provided.
+     *
+     * @param parent
+     */
+    public void show(ViewGroup parent) {
+        MarginLayoutParams params = init(parent.getContext(), null, parent);
+        updateLayoutParamsMargins(null, params);
+        showInternal(null, params, parent);
+    }
+
+    private void showInternal(Activity targetActivity, MarginLayoutParams params, ViewGroup parent) {
+        parent.removeView(this);
+
+        parent.addView(this, params);
 
         bringToFront();
 
         // As requested in the documentation for bringToFront()
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-            root.requestLayout();
-            root.invalidate();
+            parent.requestLayout();
+            parent.invalidate();
         }
 
         mIsShowing = true;
@@ -784,7 +823,7 @@ public class Snackbar extends SnackbarLayout {
     protected void updateLayoutParamsMargins(Activity targetActivity, MarginLayoutParams params) {
         Resources res = getResources();
 
-        if (res.getBoolean(R.bool.sb__is_phone)) {
+        if (shouldUsePhoneLayout(targetActivity)) {
             // Phone
             params.topMargin = 0;
             params.rightMargin = 0;

--- a/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
@@ -3,6 +3,7 @@ package com.nispok.snackbar;
 import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.util.Log;
+import android.view.ViewGroup;
 
 /**
  * A handler for multiple {@link Snackbar}s
@@ -53,6 +54,27 @@ public class SnackbarManager {
         }
         currentSnackbar = snackbar;
         currentSnackbar.show(activity);
+    }
+
+    /**
+     * Displays a {@link com.nispok.snackbar.Snackbar} in the specified {@link ViewGroup}, dismissing
+     * the current Snackbar being displayed, if any
+     *
+     * @param snackbar instance of {@link com.nispok.snackbar.Snackbar} to display
+     * @param parent parent {@link ViewGroup} to display the Snackbar
+     */
+    public static void show(@NonNull Snackbar snackbar, @NonNull ViewGroup parent) {
+        if (currentSnackbar != null) {
+            if(currentSnackbar.isShowing() && !currentSnackbar.isDimissing()) {
+                currentSnackbar.dismissByReplace();
+                currentSnackbar = snackbar;
+                currentSnackbar.showByReplace(parent);
+                return;
+            }
+            currentSnackbar.dismiss();
+        }
+        currentSnackbar = snackbar;
+        currentSnackbar.show(parent);
     }
 
     /**

--- a/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
@@ -64,17 +64,29 @@ public class SnackbarManager {
      * @param parent parent {@link ViewGroup} to display the Snackbar
      */
     public static void show(@NonNull Snackbar snackbar, @NonNull ViewGroup parent) {
+        show(snackbar, parent, Snackbar.shouldUsePhoneLayout(snackbar.getContext()));
+    }
+
+    /**
+     * Displays a {@link com.nispok.snackbar.Snackbar} in the specified {@link ViewGroup}, dismissing
+     * the current Snackbar being displayed, if any
+     *
+     * @param snackbar instance of {@link com.nispok.snackbar.Snackbar} to display
+     * @param parent parent {@link ViewGroup} to display the Snackbar
+     * @param usePhoneLayout true: use phone layout, false: use tablet layout
+     */
+    public static void show(@NonNull Snackbar snackbar, @NonNull ViewGroup parent, boolean usePhoneLayout) {
         if (currentSnackbar != null) {
             if(currentSnackbar.isShowing() && !currentSnackbar.isDimissing()) {
                 currentSnackbar.dismissByReplace();
                 currentSnackbar = snackbar;
-                currentSnackbar.showByReplace(parent);
+                currentSnackbar.showByReplace(parent, usePhoneLayout);
                 return;
             }
             currentSnackbar.dismiss();
         }
         currentSnackbar = snackbar;
-        currentSnackbar.show(parent);
+        currentSnackbar.show(parent, usePhoneLayout);
     }
 
     /**

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         <activity android:name=".SnackbarRecyclerViewSampleActivity" />
         <activity android:name=".SnackbarNavigationBarTranslucentSampleActivity" />
         <activity android:name=".SnackbarImmersiveModeSampleActivity" />
+        <activity android:name=".SnackbarShowInDialogSampleActivity" />
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
@@ -275,6 +275,16 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                 }
             }
         });
+
+        Button showInDialogButton = (Button) findViewById(R.id.show_in_dialog_example);
+        showInDialogButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent sampleIntent = new Intent(SnackbarSampleActivity.this,
+                        SnackbarShowInDialogSampleActivity.class);
+                startActivity(sampleIntent);
+            }
+        });
     }
 
     @Override

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarShowInDialogSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarShowInDialogSampleActivity.java
@@ -1,0 +1,128 @@
+package com.nispok.samples.snackbar;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.ActionBarActivity;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ListView;
+
+import com.nispok.snackbar.Snackbar;
+import com.nispok.snackbar.SnackbarManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static android.widget.AdapterView.OnItemClickListener;
+
+public class SnackbarShowInDialogSampleActivity extends ActionBarActivity {
+
+    private static final String TAG = SnackbarShowInDialogSampleActivity.class.getSimpleName();
+    private static final String FRAGMENT_TAG_MY_DIALOG = "MyDialog";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_show_in_dialog_sample);
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        final Button button = (Button) findViewById(android.R.id.button1);
+
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                openDialog();
+            }
+        });
+    }
+
+    private void openDialog() {
+        getSupportFragmentManager()
+                .beginTransaction()
+                .add(new MyDialogFragment(), FRAGMENT_TAG_MY_DIALOG)
+                .commit();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+    public static class MyDialogFragment extends DialogFragment implements OnItemClickListener {
+        private ViewGroup mSnackbarContainer;
+        private ListView mListView;
+
+        @NonNull
+        @Override
+        public Dialog onCreateDialog(Bundle savedInstanceState) {
+            Context context = getActivity();
+            AlertDialog.Builder builder = new AlertDialog.Builder(context);
+
+            View view = LayoutInflater.from(context).inflate(R.layout.fragment_dialog_list, null, false);
+
+            mListView = (ListView) view.findViewById(android.R.id.list);
+            mSnackbarContainer = (ViewGroup) view.findViewById(R.id.snackbar_container);
+
+            List<String> data = new ArrayList<String>();
+
+            for (int i = 0; i < 25; i++) {
+                data.add(String.format("Item %d", (i + 1)));
+            }
+
+            ArrayAdapter<String> adapter = new ArrayAdapter<String>(
+                    context, android.R.layout.simple_list_item_1, data);
+
+            mListView.setAdapter(adapter);
+            mListView.setOnItemClickListener(this);
+
+            builder.setView(view);
+            builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                }
+            });
+
+            return builder.create();
+        }
+
+        @Override
+        public void onDismiss(DialogInterface dialog) {
+            super.onDismiss(dialog);
+
+            mListView.setOnItemClickListener(null);
+            mListView = null;
+            mSnackbarContainer = null;
+        }
+
+        @Override
+        public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+            SnackbarManager.show(
+                    Snackbar.with(getActivity())
+                            .text(String.format("Item %d pressed", (position + 1)))
+                            .actionLabel("Close")
+                            .actionColor(Color.parseColor("#FF8A80"))
+                            .duration(Snackbar.SnackbarDuration.LENGTH_LONG)
+                            .attachToAbsListView(mListView),
+                    mSnackbarContainer);
+
+        }
+    }
+}

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarShowInDialogSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarShowInDialogSampleActivity.java
@@ -121,7 +121,7 @@ public class SnackbarShowInDialogSampleActivity extends ActionBarActivity {
                             .actionColor(Color.parseColor("#FF8A80"))
                             .duration(Snackbar.SnackbarDuration.LENGTH_LONG)
                             .attachToAbsListView(mListView),
-                    mSnackbarContainer);
+                    mSnackbarContainer, true);
 
         }
     }

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -97,5 +97,11 @@
             android:layout_height="wrap_content"
             android:text="Immersive Mode"/>
 
+        <Button
+            android:id="@+id/show_in_dialog_example"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Show in Dialog"/>
+
     </LinearLayout>
 </ScrollView>

--- a/sample/src/main/res/layout/activity_show_in_dialog_sample.xml
+++ b/sample/src/main/res/layout/activity_show_in_dialog_sample.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@android:id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="Open Dialog" />
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/fragment_dialog_list.xml
+++ b/sample/src/main/res/layout/fragment_dialog_list.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/background_light"
+    android:gravity="bottom">
+
+    <ListView
+        android:id="@android:id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <RelativeLayout
+        android:id="@+id/snackbar_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@android:id/list" />
+
+</RelativeLayout>


### PR DESCRIPTION
This pull request introduces these methods;
- `SnackbarManager.show(Snackbar snackbar, ViewGroup parent)`
- `SnackbarManager.show(Snackbar snackbar, ViewGroup parent, boolean usePhoneLayout)`

These methods enables that users can specify where to place the Snackbar in the hierarchy of views. It solves these issues;
- #76 Snackbar appears behind dialogs 
- #62 show() as a child view
- #27 Added fragment sometimes overlays the snackbar

Also I have added an example ("Show in DIalog") which demonstrates the new method.