### PR TITLE
Add swipe to dismiss listener

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -30,6 +30,7 @@ import android.widget.TextView;
 import com.nispok.snackbar.enums.SnackbarType;
 import com.nispok.snackbar.layouts.SnackbarLayout;
 import com.nispok.snackbar.listeners.ActionClickListener;
+import com.nispok.snackbar.listeners.ActionSwipeListener;
 import com.nispok.snackbar.listeners.EventListener;
 import com.nispok.snackbar.listeners.SwipeDismissTouchListener;
 
@@ -70,6 +71,7 @@ public class Snackbar extends SnackbarLayout {
     private boolean mIsShowingByReplace = false;
     private long mCustomDuration = -1;
     private ActionClickListener mActionClickListener;
+    private ActionSwipeListener mActionSwipeListener;
     private boolean mShouldAllowMultipleActionClicks;
     private boolean mActionClicked;
     private boolean mShouldDismissOnActionClicked = true;
@@ -252,6 +254,18 @@ public class Snackbar extends SnackbarLayout {
      */
     public Snackbar actionListener(ActionClickListener listener) {
         mActionClickListener = listener;
+        return this;
+    }
+
+
+    /**
+     * Sets the listener to be called when the {@link Snackbar} is dismissed by swipe.
+     *
+     * @param listener
+     * @return
+     */
+    public Snackbar swipeListener(ActionSwipeListener listener) {
+        mActionSwipeListener = listener;
         return this;
     }
 
@@ -498,6 +512,9 @@ public class Snackbar extends SnackbarLayout {
                         @Override
                         public void onDismiss(View view, Object token) {
                             if (view != null) {
+                                if (mActionSwipeListener != null) {
+                                    mActionSwipeListener.onSwipeToDismiss();
+                                }
                                 dismiss(false);
                             }
                         }

--- a/lib/src/main/java/com/nispok/snackbar/listeners/ActionSwipeListener.java
+++ b/lib/src/main/java/com/nispok/snackbar/listeners/ActionSwipeListener.java
@@ -1,0 +1,6 @@
+package com.nispok.snackbar.listeners;
+
+public interface ActionSwipeListener {
+
+    void onSwipeToDismiss();
+}

--- a/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
+++ b/sample/src/main/java/com/nispok/samples/snackbar/SnackbarSampleActivity.java
@@ -18,6 +18,7 @@ import com.nispok.snackbar.Snackbar;
 import com.nispok.snackbar.SnackbarManager;
 import com.nispok.snackbar.enums.SnackbarType;
 import com.nispok.snackbar.listeners.ActionClickListener;
+import com.nispok.snackbar.listeners.ActionSwipeListener;
 import com.nispok.snackbar.listeners.EventListener;
 
 public class SnackbarSampleActivity extends ActionBarActivity {
@@ -47,6 +48,14 @@ public class SnackbarSampleActivity extends ActionBarActivity {
                         Snackbar.with(SnackbarSampleActivity.this)
                                 .text("Something has been done")
                                 .actionLabel("Undo")
+                                .swipeListener(new ActionSwipeListener() {
+                                    @Override
+                                    public void onSwipeToDismiss() {
+                                        Toast.makeText(SnackbarSampleActivity.this,
+                                                "swipe to dismiss",
+                                                Toast.LENGTH_SHORT).show();
+                                    }
+                                })
                                 .actionListener(new ActionClickListener() {
                                     @Override
                                     public void onActionClicked(Snackbar snackbar) {


### PR DESCRIPTION
Adds a swipe to dismiss listener to the snackbar, which is required for some use cases, where it is not sufficient to implement the onDismiss or onDismissed callback.