### PR TITLE
.maxWidthPercentage(float width) method

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/DisplayCompat.java
+++ b/lib/src/main/java/com/nispok/snackbar/DisplayCompat.java
@@ -1,5 +1,6 @@
 package com.nispok.snackbar;
 
+import android.app.Activity;
 import android.graphics.Point;
 import android.os.Build;
 import android.view.Display;
@@ -29,5 +30,13 @@ class DisplayCompat {
 
     public static void getRealSize(Display display, Point outSize) {
         IMPL.getRealSize(display, outSize);
+    }
+
+    public static int getWidthFromPercentage(Activity targetActivity, Float mMaxWidthPercentage) {
+        Display display = targetActivity.getWindowManager().getDefaultDisplay();
+        Point dispSize = new Point();
+        getRealSize(display, dispSize);
+
+        return (int) (dispSize.x * mMaxWidthPercentage);
     }
 }

--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -99,6 +99,7 @@ public class Snackbar extends SnackbarLayout {
     private Point mDisplaySize = new Point();
     private Point mRealDisplaySize = new Point();
     private Activity mTargetActivity;
+    private Float mMaxWidthPercentage = null;
     private boolean mUsePhoneLayout;
     private Runnable mDismissRunnable = new Runnable() {
         @Override
@@ -531,7 +532,10 @@ public class Snackbar extends SnackbarLayout {
             // Tablet/desktop
             mType = SnackbarType.SINGLE_LINE; // Force single-line
             layout.setMinimumWidth(res.getDimensionPixelSize(R.dimen.sb__min_width));
-            layout.setMaxWidth(res.getDimensionPixelSize(R.dimen.sb__max_width));
+            layout.setMaxWidth(
+                    mMaxWidthPercentage == null
+                    ? res.getDimensionPixelSize(R.dimen.sb__max_width)
+                    : DisplayCompat.getWidthFromPercentage(targetActivity , mMaxWidthPercentage));
             layout.setBackgroundResource(R.drawable.sb__bg);
             GradientDrawable bg = (GradientDrawable) layout.getBackground();
             bg.setColor(mColor);
@@ -723,6 +727,11 @@ public class Snackbar extends SnackbarLayout {
         MarginLayoutParams params = init(parent.getContext(), null, parent, usePhoneLayout);
         updateLayoutParamsMargins(null, params);
         showInternal(null, params, parent);
+    }
+
+    public Snackbar maxWidthPercentage(float maxWidthPercentage) {
+        mMaxWidthPercentage = maxWidthPercentage;
+        return this;
     }
 
     private void showInternal(Activity targetActivity, MarginLayoutParams params, ViewGroup parent) {


### PR DESCRIPTION
Adds the ability to set the desired width of the Snackbar on tablets. The maximum width of the message was set to
<dimen name="sb__max_width">568dp</dimen> in dimens.xml which was too narrow for me. I wanted to have a full-width message on the bottom of the tablet's screen.

Sample usage is:
Snackbar.with(getApplicationContext())
      .text("Message text")
      .maxWidthPercentage(0.95f)
      .show(this);