### PR TITLE
Make snackbar components focusable and fire accessibility event on show

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -14,6 +14,7 @@ import android.support.annotation.AnimRes;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
+import android.support.v4.view.accessibility.AccessibilityEventCompat;
 import android.text.TextUtils;
 import android.view.Display;
 import android.view.Gravity;
@@ -22,6 +23,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
+import android.view.accessibility.AccessibilityEvent;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.AbsListView;
@@ -804,6 +806,8 @@ public class Snackbar extends SnackbarLayout {
                     mIsShowingByReplace = false; // reset flag
                 }
 
+                focusForAccessibility(snackbarText);
+
                 post(new Runnable() {
                     @Override
                     public void run() {
@@ -824,6 +828,14 @@ public class Snackbar extends SnackbarLayout {
             }
         });
         startAnimation(slideIn);
+    }
+
+    private void focusForAccessibility(View view) {
+        final AccessibilityEvent event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+
+        AccessibilityEventCompat.asRecord(event).setSource(view);
+
+        view.sendAccessibilityEventUnchecked(event);
     }
 
     private boolean shouldStartTimer() {

--- a/lib/src/main/res/layout/sb__template.xml
+++ b/lib/src/main/res/layout/sb__template.xml
@@ -8,7 +8,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
-        android:ellipsize="end" />
+        android:ellipsize="end"
+        android:focusable="true" />
 
     <TextView
         android:id="@+id/sb__action"
@@ -16,6 +17,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        android:gravity="right" />
+        android:gravity="right"
+        android:focusable="true" />
 
 </merge>


### PR DESCRIPTION
This makes both of the inner TextViews focusable and explicitly focuses the text through an accessibility event when it is shown.  Using TalkBack navigation gestures from there will next focus the action text if it exists.

A further enhancement that could be made for accessibility would be to do something different with default durations if an accessibility service is enabled to allow a user more time to take action.  Although maybe it's better left up to the user of the library to handle those cases and adjust the durations accordingly.