### PR TITLE
Fix dismissByReplace jarring animation

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -93,7 +93,8 @@ public class Snackbar extends SnackbarLayout {
     private long mTimeRemaining = -1;
     private CharSequence mActionLabel;
     private int mActionColor = mUndefinedColor;
-    private boolean mAnimated = true;
+    private boolean mShowAnimated = true;
+    private boolean mDismissAnimated = true;
     private boolean mIsReplacePending = false;
     private boolean mIsShowingByReplace = false;
     private long mCustomDuration = -1;
@@ -387,13 +388,36 @@ public class Snackbar extends SnackbarLayout {
     }
 
     /**
-     * Sets on/off animation for this {@link Snackbar}
+     * Sets on/off both show and dismiss animations for this {@link Snackbar}
      *
      * @param withAnimation
      * @return
      */
     public Snackbar animation(boolean withAnimation) {
-        mAnimated = withAnimation;
+        mShowAnimated = withAnimation;
+        mDismissAnimated = withAnimation;
+        return this;
+    }
+
+    /**
+     * Sets on/off show animation for this {@link Snackbar}
+     *
+     * @param withAnimation
+     * @return
+     */
+    public Snackbar showAnimation(boolean withAnimation) {
+        mShowAnimated = withAnimation;
+        return this;
+    }
+
+    /**
+     * Sets on/off dismiss animation for this {@link Snackbar}
+     *
+     * @param withAnimation
+     * @return
+     */
+    public Snackbar dismissAnimation(boolean withAnimation) {
+        mDismissAnimated = withAnimation;
         return this;
     }
 
@@ -777,7 +801,7 @@ public class Snackbar extends SnackbarLayout {
                     } else {
                         mEventListener.onShow(Snackbar.this);
                     }
-                    if (!mAnimated) {
+                    if (!mShowAnimated) {
                         mEventListener.onShown(Snackbar.this);
                         mIsShowingByReplace = false; // reset flag
                     }
@@ -786,7 +810,7 @@ public class Snackbar extends SnackbarLayout {
             }
         });
 
-        if (!mAnimated) {
+        if (!mShowAnimated) {
             if (shouldStartTimer()) {
                 startTimer();
             }
@@ -882,7 +906,7 @@ public class Snackbar extends SnackbarLayout {
     }
 
     public void dismiss() {
-        dismiss(mAnimated);
+        dismiss(mDismissAnimated);
     }
 
     private void dismiss(boolean animate) {
@@ -1050,8 +1074,19 @@ public class Snackbar extends SnackbarLayout {
         return mOffset;
     }
 
+    /**
+     * @return true only if both dismiss and show animations are enabled
+     */
     public boolean isAnimated() {
-        return mAnimated;
+        return mShowAnimated && mDismissAnimated;
+    }
+
+    public boolean isDismissAnimated(){
+        return mDismissAnimated;
+    }
+
+    public boolean isShowAnimated(){
+        return mShowAnimated;
     }
 
     public boolean shouldDismissOnActionClicked() {

--- a/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
+++ b/lib/src/main/java/com/nispok/snackbar/SnackbarManager.java
@@ -51,8 +51,10 @@ public class SnackbarManager {
             public void run() {
                 if (currentSnackbar != null) {
                     if (currentSnackbar.isShowing() && !currentSnackbar.isDimissing()) {
+                        currentSnackbar.dismissAnimation(false);
                         currentSnackbar.dismissByReplace();
                         currentSnackbar = snackbar;
+                        currentSnackbar.showAnimation(false);
                         currentSnackbar.showByReplace(activity);
                         return;
                     }
@@ -90,8 +92,10 @@ public class SnackbarManager {
             public void run() {
                 if (currentSnackbar != null) {
                     if (currentSnackbar.isShowing() && !currentSnackbar.isDimissing()) {
+                        currentSnackbar.dismissAnimation(false);
                         currentSnackbar.dismissByReplace();
                         currentSnackbar = snackbar;
+                        currentSnackbar.showAnimation(false);
                         currentSnackbar.showByReplace(parent, usePhoneLayout);
                         return;
                     }


### PR DESCRIPTION
Separated the mAnimated field of Snackbar into 2 fields: mShowAnimated
and mDismissAnimated with each field having its own getter and setter
methods. withAnimation(boolean) will change both of these values and
isAnimated() will return true only if both of them are set to true.

In SnackBarManager when replacing a snackbar, dimissAnimation(false) is
called on the previous snackbar and showAnimation(false) is called on
the new snackbar. This provided much smoother visuals when dismissing by
replace.