### PR TITLE
Support for colored top line

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -82,6 +82,7 @@ public class Snackbar extends SnackbarLayout {
     private int mColor = mUndefinedColor;
     private int mTextColor = mUndefinedColor;
     private int mOffset;
+    private Integer mLineColor;
     private SnackbarPosition mPosition = SnackbarPosition.BOTTOM;
     private int mDrawable = mUndefinedDrawable;
     private int mMarginTop = 0;
@@ -228,6 +229,27 @@ public class Snackbar extends SnackbarLayout {
      */
     public Snackbar textColorResource(@ColorRes int resId) {
         return textColor(getResources().getColor(resId));
+    }
+
+    /**
+     * Sets the text color of this {@link Snackbar}'s top line, or null for none
+     *
+     * @param lineColor
+     * @return
+     */
+    public Snackbar lineColor(Integer lineColor) {
+        mLineColor = lineColor;
+        return this;
+    }
+
+    /**
+     * Sets the text color of this {@link Snackbar}'s top line
+     *
+     * @param resId
+     * @return
+     */
+    public Snackbar lineColorResource(@ColorRes int resId) {
+        return lineColor(getResources().getColor(resId));
     }
 
     /**
@@ -554,6 +576,7 @@ public class Snackbar extends SnackbarLayout {
     private MarginLayoutParams init(Context context, Activity targetActivity, ViewGroup parent, boolean usePhoneLayout) {
         SnackbarLayout layout = (SnackbarLayout) LayoutInflater.from(context)
                 .inflate(R.layout.sb__template, this, true);
+        layout.setOrientation(LinearLayout.VERTICAL);
 
         Resources res = getResources();
         mColor = mColor != mUndefinedColor ? mColor : res.getColor(R.color.sb__background);
@@ -587,6 +610,12 @@ public class Snackbar extends SnackbarLayout {
 
         if (mDrawable != mUndefinedDrawable)
             setBackgroundDrawable(layout, res.getDrawable(mDrawable));
+
+        if (mLineColor != null) {
+            layout.findViewById(R.id.sb__divider).setBackgroundColor(mLineColor);
+        } else {
+            layout.findViewById(R.id.sb__divider).setVisibility(View.GONE);
+        }
 
         snackbarText = (TextView) layout.findViewById(R.id.sb__text);
         snackbarText.setText(mText);
@@ -1044,6 +1073,10 @@ public class Snackbar extends SnackbarLayout {
 
     public int getColor() {
         return mColor;
+    }
+
+    public int getLineColor() {
+        return mLineColor;
     }
 
     public CharSequence getText() {

--- a/lib/src/main/res/layout/sb__template.xml
+++ b/lib/src/main/res/layout/sb__template.xml
@@ -2,22 +2,33 @@
 
 <merge xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <TextView
-        android:id="@+id/sb__text"
-        style="@style/Snackbar.Text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:ellipsize="end"
-        android:focusable="true" />
+    <View
+        android:id="@+id/sb__divider"
+        android:layout_width="match_parent"
+        android:layout_height="3dp" />
 
-    <TextView
-        android:id="@+id/sb__action"
-        style="@style/Snackbar.Text.Action"
-        android:layout_width="wrap_content"
+    <LinearLayout
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:gravity="right"
-        android:focusable="true" />
+        android:layout_width="match_parent">
+
+        <TextView
+            android:id="@+id/sb__text"
+            style="@style/Snackbar.Text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:focusable="true" />
+
+        <TextView
+            android:id="@+id/sb__action"
+            style="@style/Snackbar.Text.Action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:gravity="right"
+            android:focusable="true" />
+
+    </LinearLayout>
 
 </merge>


### PR DESCRIPTION
This adds a way to have a small indicator line on top of the snackbar to display if it's an error/informational/warning/ok...

This was proposed somewhere on Google+, but I can't find the reference anymore.

Screenshots:
![device-2015-04-30-010736](https://cloud.githubusercontent.com/assets/321888/7403385/6ee9d7f2-eed5-11e4-94f6-434208ab9c22.png)
![device-2015-04-30-010824](https://cloud.githubusercontent.com/assets/321888/7403386/6eea218a-eed5-11e4-843c-adb81a25ea24.png)
