### PR TITLE
On Lollipop make sure the Snackbar elevation is the same as other children

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -807,6 +807,17 @@ public class Snackbar extends SnackbarLayout {
     private void showInternal(Activity targetActivity, MarginLayoutParams params, ViewGroup parent) {
         parent.removeView(this);
 
+        // We need to make sure the Snackbar elevation is at least as high as
+        // any other child views, or it will be displayed underneath them
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            for (int i = 0; i < parent.getChildCount(); i++) {
+                View otherChild = parent.getChildAt(i);
+                float elvation = otherChild.getElevation();
+                if (elvation > getElevation()) {
+                    setElevation(elvation);
+                }
+            }
+        }
         parent.addView(this, params);
 
         bringToFront();

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:elevation="16dp"
     tools:context="com.nispok.samples.snackbar.SnackbarSampleActivity">
 
     <LinearLayout


### PR DESCRIPTION
This fixes issue #109, where the Snackbar is displaying under the rest of the view. On Lollipop we need to make sure that the elevation of the Snackbar is as high as the other child view(s).