### PR TITLE
added min_width max_width to default values.xml

### DIFF
--- a/lib/src/main/res/values/dimens.xml
+++ b/lib/src/main/res/values/dimens.xml
@@ -7,4 +7,6 @@
     <dimen name="sb__text_padding_top">14dp</dimen>
     <dimen name="sb__text_padding_right">24dp</dimen>
     <dimen name="sb__text_size">14sp</dimen>
+    <dimen name="sb__min_width">288dp</dimen>
+    <dimen name="sb__max_width">568dp</dimen>
 </resources>


### PR DESCRIPTION
This fixes a crash when calling 
SnackbarManager.show(snackbar,false) on devices where the smallest width is less than 600dp, such as the nexus 5. It would throw a resource not found exception because the only value specified for the resource is in values-sw600dp

Particularly, it would crash on line layout.setMinimumWidth(res.getDimensionPixelSize(dimen.sb__min_width)); in
 private MarginLayoutParams init(Context context, Activity targetActivity, ViewGroup parent, boolean usePhoneLayout)
of snackbar.java because it's being forced to use the tablet specific implementation when it would not normally do so, namely when the width is less than 600dp on a device like the nexus 5 which is 360.0 dp x 592.0 dp
