### PR TITLE
round corners on divider line in tablet layout

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -597,6 +597,8 @@ public class Snackbar extends SnackbarLayout {
         mUsePhoneLayout = usePhoneLayout;
         float scale = res.getDisplayMetrics().density;
 
+        View divider = layout.findViewById(R.id.sb__divider);
+
         MarginLayoutParams params;
         if (mUsePhoneLayout) {
             // Phone
@@ -605,6 +607,12 @@ public class Snackbar extends SnackbarLayout {
             layout.setBackgroundColor(mColor);
             params = createMarginLayoutParams(
                     parent, FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT, mPhonePosition);
+
+            if (mLineColor != null) {
+                divider.setBackgroundColor(mLineColor);
+            } else {
+                divider.setVisibility(View.GONE);
+            }
         } else {
             // Tablet/desktop
             mType = SnackbarType.SINGLE_LINE; // Force single-line
@@ -619,16 +627,18 @@ public class Snackbar extends SnackbarLayout {
 
             params = createMarginLayoutParams(
                     parent, FrameLayout.LayoutParams.WRAP_CONTENT, dpToPx(mType.getMaxHeight(), scale), mWidePosition);
+
+            if (mLineColor != null) {
+                divider.setBackgroundResource(R.drawable.sb__divider_bg);
+                GradientDrawable dbg = (GradientDrawable) divider.getBackground();
+                dbg.setColor(mLineColor);
+            } else {
+                divider.setVisibility(View.GONE);
+            }
         }
 
         if (mDrawable != mUndefinedDrawable)
             setBackgroundDrawable(layout, res.getDrawable(mDrawable));
-
-        if (mLineColor != null) {
-            layout.findViewById(R.id.sb__divider).setBackgroundColor(mLineColor);
-        } else {
-            layout.findViewById(R.id.sb__divider).setVisibility(View.GONE);
-        }
 
         snackbarText = (TextView) layout.findViewById(R.id.sb__text);
         snackbarText.setText(mText);

--- a/lib/src/main/res/drawable/sb__divider_bg.xml
+++ b/lib/src/main/res/drawable/sb__divider_bg.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/sb__background"/>
+    <corners
+        android:topRightRadius="@dimen/sb__bg_corner_radius"
+        android:topLeftRadius="@dimen/sb__bg_corner_radius"
+        />
+</shape>


### PR DESCRIPTION
minor nitpick pull request! =)

on tablets, a snackbar has round corners. with this commit, a snackbar with a top line ('divider') will also have round top corners
