### PR TITLE
nicer animation flow for dismiss on swipe

### DIFF
--- a/lib/src/main/java/com/nispok/snackbar/Snackbar.java
+++ b/lib/src/main/java/com/nispok/snackbar/Snackbar.java
@@ -674,10 +674,11 @@ public class Snackbar extends SnackbarLayout {
             snackbarAction.setVisibility(GONE);
         }
 
-        setClickable(true);
+        View inner = layout.findViewById(R.id.sb__inner);
+        inner.setClickable(true);
 
         if (mCanSwipeToDismiss && res.getBoolean(R.bool.sb__is_swipeable)) {
-            setOnTouchListener(new SwipeDismissTouchListener(this, null,
+            inner.setOnTouchListener(new SwipeDismissTouchListener(this, null,
                     new SwipeDismissTouchListener.DismissCallbacks() {
                         @Override
                         public boolean canDismiss(Object token) {

--- a/lib/src/main/res/layout/sb__template.xml
+++ b/lib/src/main/res/layout/sb__template.xml
@@ -8,6 +8,7 @@
         android:layout_height="3dp" />
 
     <LinearLayout
+        android:id="@+id/sb__inner"
         android:layout_height="wrap_content"
         android:layout_width="match_parent">
 


### PR DESCRIPTION
...maybe "different" animation flow is a less opinionated term here.

snackbars are moved in from the bottom and are affixed to both screen edges (on non-tablet screens). I never quite liked how swiping the snackbar exposed the left or right edge, breaking its "full width, moved in from bottom" vibe. swiping it down to dismiss, as the guidelines say, is not very intuitive either.

this commit is a compromise which keeps side-swiping while keeping the edges fixed: swiping behavior is unchanged, but now only the _content_ of the snackbar is moved, while the snackbar (i.e. its background) fades out but stays in place.

I tried different animations for actually dismissing the background afterwards, and fading it out the rest of the way felt better than moving it off the bottom of the screen for the swipe flow.

related note: your library has several advantages over the one from the support library, please keep maintaining it! :+1:
